### PR TITLE
refactor: update GenericRelationship type properties for clarity

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,9 +12,9 @@ export type FlarebaseClientOptions = {
 }
 
 export type GenericRelationship = {
-    foreignKeyName: string
-    columns: string[]
-    referencedTable: string
+    constraintName: string
+    localColumns: string[]
+    referencedTableName: string
     referencedColumns: string[]
     isOneToOne?: boolean
 }


### PR DESCRIPTION
This pull request includes a modification to the `GenericRelationship` type in the `src/lib/types.ts` file to improve clarity and consistency in naming conventions.

### Changes to `GenericRelationship` type:

* Renamed `foreignKeyName` to `constraintName` for better alignment with database terminology.
* Renamed `columns` to `localColumns` to clarify that these are the columns in the local table.
* Renamed `referencedTable` to `referencedTableName` for consistency with other property names.