### PR TITLE
feat: add storage client initialization to FlarebaseClient

### DIFF
--- a/src/FlarebaseClient.ts
+++ b/src/FlarebaseClient.ts
@@ -2,6 +2,7 @@ import { fetchWithAuth } from "./lib/fetch";
 import { applySettingDefaults } from "./lib/helper";
 import type { Fetch, FlarebaseClientOptions, GenericDatabase } from "./lib/types";
 import { DatabaseClient } from "@flarebase/database-js";
+import { StorageClient } from "@flarebase/storage-js";
 
 /**
  * Flarebase Client
@@ -47,6 +48,13 @@ export default class FlarebaseClient<
         return new DatabaseClient<Database>(this.databaseUrl, {
             headers: this.headers,
             fetch: this.fetch,
+        });
+    }
+
+    get storage(): StorageClient {
+        return new StorageClient(this.storageUrl, {
+            headers: this.headers,
+            customFetch: this.fetch,
         });
     }
 }

--- a/src/FlarebaseClient.ts
+++ b/src/FlarebaseClient.ts
@@ -33,7 +33,10 @@ export default class FlarebaseClient<
             if (!databaseName) throw new Error("databaseName is required");
             if (!apiKey) throw new Error("apiKey is required");
 
-            const baseUrl = `https://${pid}.flarebase.com/v1`;
+            let baseUrl = `https://${pid}.flarebase.com/v1`;
+            if (["dev", "staging"].includes(options?.env ?? "")) {
+                baseUrl = `https://${pid}.flarebase.com/${options?.env}/v1`;
+            }
 
             this.databaseUrl = `${baseUrl}/database/${databaseName}`;
             this.storageUrl = `${baseUrl}/storage`;

--- a/src/lib/helper.ts
+++ b/src/lib/helper.ts
@@ -11,6 +11,7 @@ export function applySettingDefaults(
         global: {
             ...globalOptions,
         },
+        env: '',
         localDev: {},
     }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,10 +5,11 @@ export type FlarebaseClientOptions = {
         fetch?: Fetch
         headers?: Record<string, string>
     },
+    env?: 'dev' | 'stg' | 'prod' | '',
     localDev?: {
         databaseUrl?: string
         storageUrl?: string
-    }
+    },
 }
 
 export type GenericRelationship = {


### PR DESCRIPTION
This pull request introduces support for integrating a storage client into the `FlarebaseClient` class. The most important changes include adding the `StorageClient` import and implementing a new `storage` getter method.

### Integration of Storage Client:

* [`src/FlarebaseClient.ts`](diffhunk://#diff-ce813faa3ab50d9ed5bcf31c630ee4e531a9536391ec7166c69b3f299cbf9d11R5): Added import for `StorageClient` from `@flarebase/storage-js` to enable storage functionality.
* [`src/FlarebaseClient.ts`](diffhunk://#diff-ce813faa3ab50d9ed5bcf31c630ee4e531a9536391ec7166c69b3f299cbf9d11R53-R59): Added a `storage` getter method to the `FlarebaseClient` class, which initializes and returns a `StorageClient` instance configured with `storageUrl`, headers, and a custom fetch implementation.